### PR TITLE
Added tox file and configured flake 8 and tests.

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,4 +2,3 @@ class Config(object):
     DEBUG = True
     DASHBOARD_HOST = '0.0.0.0'
     DASHBOARD_PORT = 8080
-    

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from distutils.core import setup
+
+setup(name='pyDuesPal',
+      version='1.0',
+      description='Python PayPal dues tracking system',
+      packages=['web_site'],
+      )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+discover

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,33 @@
+; NOTE: To anyone that modifies this file, it must work on both windows and *nix. We need to show our windows friends
+; some love and stay compatible ;-).
+[tox]
+envlist = py27,py35,pep8
+
+[testenv]
+usedevelop = True
+setenv = VIRTUAL_ENV={envdir}
+deps = -rrequirements.txt
+       -rtest-requirements.txt
+;       -rdoc-requirements.txt
+;changedir=tests
+commands=discover
+;commands = find . -type f -name "*.pyc" -delete
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py35]
+basepython = python3.5
+
+[testenv:pep8]
+basepython=python
+deps=flake8
+commands=flake8
+
+[flake8]
+# Ignoring O321 because it's unnecessarily restricting use of json package.
+# jsonutils version doesn't add additional value
+;ignore = O321
+show-source = true
+builtins = _
+exclude = .venv,.git,.tox,dist,doc,*lib/python*,*egg,build

--- a/web_site/run.py
+++ b/web_site/run.py
@@ -12,6 +12,7 @@ def _build_app(config_to_use,
     app.register_blueprint(siteroot_module)
     return app
 
+
 def main():
     config = 'config.Config'
     app = _build_app(config)

--- a/web_site/web/siteroot/controller.py
+++ b/web_site/web/siteroot/controller.py
@@ -2,7 +2,7 @@ import flask
 
 mod = flask.Blueprint('siteroot', __name__, url_prefix='')
 
+
 @mod.route('/')
 def home():
     return flask.render_template('siteroot/home.html')
-    


### PR DESCRIPTION
### Summary

Added `tox.ini` and `setup.py` files. Configured tests to be run in both py27 and py34. Also enabled pep8 validation. Lastly I corrected the existing PEP8 violations in the base of the project.
### Testing
- If you don't have tox execute `pip install tox` to get it installed on your system
- run `tox` from the root directory of the project (same location as `tox.ini`). 
- Verify three green lines display as successful.
